### PR TITLE
docs: Update did:cheqd links

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Are you developing a DID method and Universal Registrar driver? Click [Driver De
 | [did-web](https://github.com/decentralized-identity/uni-registrar-driver-did-web/)     | 1.0.0          | [0.0](https://w3c-ccg.github.io/did-method-web/) | [universalregistrar/driver-did-web](https://hub.docker.com/r/universalregistrar/driver-did-web/)
 | [did-ebsi](https://github.com/danubetech/uni-registrar-driver-did-ebsi/)               | 1.0.0          | (missing) | [universalregistrar/driver-did-ebsi](https://hub.docker.com/r/universalregistrar/driver-did-ebsi/)
 | [did-oyd](https://github.com/OwnYourData/oydid/tree/main/uni-registrar-driver-did-oyd) | 0.5.0          | [0.5](https://ownyourdata.github.io/oydid/) | [oydeu/oydid-registrar](https://hub.docker.com/r/oydeu/oydid-registrar/)
-| [did-cheqd](https://github.com/cheqd/did-registrar)                                    | 2.0.0          | [0.0](https://docs.cheqd.io/node/architecture/adr-list/adr-002-cheqd-did-method) | [cheqd/did-registrar](https://github.com/cheqd/did-registrar/pkgs/container/did-registrar)
+| [did-cheqd](https://github.com/cheqd/did-registrar)                                    | 2.0.6          | [1.0](https://docs.cheqd.io/identity/architecture/adr-list/adr-001-cheqd-did-method) | [cheqd/did-registrar](https://github.com/cheqd/did-registrar/pkgs/container/did-registrar)
 | [did-ethr](https://github.com/danubetech/uni-registrar-driver-did-ethr/)               | 0.2.0          | [0.0](https://github.com/decentralized-identity/ethr-did-resolver/blob/master/doc/did-method-spec.md) | [universalregistrar/driver-did-ethr](https://hub.docker.com/r/universalregistrar/driver-did-ethr/)
 
 ## More Information


### PR DESCRIPTION
This update fixes links and version numbers for `did:cheqd` ADR