### PR TITLE
chore(deps): Bring base docker images in sync with Danubetech

### DIFF
--- a/uni-registrar-web/docker/Dockerfile
+++ b/uni-registrar-web/docker/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile for universalregistrar/uni-registrar-web
 
-FROM maven:3-eclipse-temurin-17-focal AS build
+FROM maven:3-eclipse-temurin-21 AS build
 MAINTAINER Markus Sabadello <markus@danubetech.com>
 
 # install dependencies
@@ -22,7 +22,7 @@ RUN cd /opt/universal-registrar/uni-registrar-web && mvn clean package -N
 
 # build image
 
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:21-jre-alpine
 MAINTAINER Markus Sabadello <markus@danubetech.com>
 
 WORKDIR /opt/universal-registrar/uni-registrar-web/


### PR DESCRIPTION
* Danubetech workflows are all Java 21
  * https://github.com/danubetech/workflows/blob/main/.github/workflows/maven-release.yml#L15-L19
  * https://github.com/danubetech/workflows/blob/main/.github/workflows/docker-release.yml#L81-L86
  * https://github.com/danubetech/workflows/blob/main/.github/workflows/maven-snapshot.yml#L6-L10
* Bump the `uni-registrar-web` base docker images to Java 21
* Opens the door to Multi-Arch (`linux/amd64`, `linux/arm64`) docker builds

---

Closes #87 