### PR TITLE
chore(deps): Upgrade Docker Actions

### DIFF
--- a/.github/workflows/docker-multi-arch.yml
+++ b/.github/workflows/docker-multi-arch.yml
@@ -75,7 +75,7 @@ jobs:
           version: latest
 
       - name: Docker Build and Cache
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ${{ inputs.PATH_TO_DOCKERFILE }}
@@ -134,14 +134,14 @@ jobs:
             type=sha,prefix=${{ steps.get_version.outputs.version }},enable=${{ inputs.IS_RELEASE == 'true' }}
 
       - name: Login to Docker Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ inputs.GLOBAL_REPO_NAME }}
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_PASSWORD }}
 
       - name: Docker Push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ${{ inputs.PATH_TO_DOCKERFILE }}


### PR DESCRIPTION
Upgrades the following actions to their latest versions:
- docker/build-push-action from v4 to v6
- docker/login-action from v2 to v3

Relates to, and hopefully fixes, #90