### PR TITLE
ci: Docker Ignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+## Recursively ignore everything
+**
+
+## Except the following
+!driver/
+!driver-http/
+!openapi/
+!uni-registrar-client/
+!uni-registrar-core/
+!uni-registrar-local/
+!uni-registrar-web/
+!src/
+!LICENSE
+!pom.xml
+!README.md
+
+## Explicitly ignore build artifacts and IDE files (based on .gitignore)
+**/target/
+**/bin/
+**/.settings/
+**/.classpath
+**/.project
+**/.idea/
+**/*.iml

--- a/.github/workflows/docker-multi-arch.yml
+++ b/.github/workflows/docker-multi-arch.yml
@@ -63,8 +63,6 @@ jobs:
           token: ${{ secrets.CI_SECRET_READER_PERIODIC_TOKEN }}
           caCertificate: ${{ secrets.VAULTCA }}
           secrets: |
-            ci/data/gh-workflows/${{ inputs.GLOBAL_REPO_NAME }} username | DOCKER_USERNAME ;
-            ci/data/gh-workflows/${{ inputs.GLOBAL_REPO_NAME }} password | DOCKER_PASSWORD ;
             ci/data/gh-workflows/maven-danubetech-nexus username | MAVEN_USERNAME ;
             ci/data/gh-workflows/maven-danubetech-nexus password | MAVEN_PASSWORD
 


### PR DESCRIPTION
* Add a whitelist `.dockerignore` which ignores everything except for
  the necessary files/directories for the docker build to work
* Significantly reduces cache invalidation

Should resolve #90 