### PR TITLE
hotfix: Use correct output from `danubetech/github-action-read-version`

### DIFF
--- a/.github/workflows/docker-multi-arch.yml
+++ b/.github/workflows/docker-multi-arch.yml
@@ -129,7 +129,7 @@ jobs:
           images: ${{ inputs.GLOBAL_REPO_NAME }}/${{ inputs.GLOBAL_IMAGE_NAME }}
           tags: |
             type=raw,value=${{ inputs.IMAGE_TAG }},enable=${{ inputs.IMAGE_TAG != '' }}
-            type=sha,prefix=${{ steps.get_version.outputs.version }},enable=${{ inputs.IS_RELEASE }}
+            type=sha,prefix=${{ steps.get_version.outputs.releaseVersion }}-,enable=${{ inputs.IS_RELEASE }}
 
       - name: Login to Docker Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
* Add missing `-` to sha prefix tag
* Use correct `releaseVersion` output from `danubetech/github-action-read-version@main`